### PR TITLE
Tightening up AWS SDK dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,17 @@
         <!-- The AWS SDK for Java -->
         <dependency>
             <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk</artifactId>
+            <artifactId>aws-java-sdk-cloudwatch</artifactId>
+            <version>${aws-java-sdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-dynamodb</artifactId>
+            <version>${aws-java-sdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-kinesis</artifactId>
             <version>${aws-java-sdk.version}</version>
         </dependency>
 


### PR DESCRIPTION
The original pom.xml had a dependency on the top-level AWS SDK
which meant that it pulled in ALL of the AWS SDK dependencies.
A perusal of the code shows there are actually only dependencies
on the cloudwatch, dynamodb, and kinesis AWS SDKs.

This update changes the POM dependencies to depend upon the
AWS SDK's cloudwatch, dynamodb, and kinesis modules instead
of the high-level AWS SDK.