### PR TITLE
Removing DynamoDBLocal Repo to s3 (Default should Maven central)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,18 +223,6 @@
             </plugin>
         </plugins>
     </build>
-
-    <repositories>
-        <repository>
-            <id>dynamodblocal</id>
-            <name>AWS DynamoDB Local Release Repository</name>
-            <url>https://s3-us-west-2.amazonaws.com/dynamodb-local/release</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
     <dependencyManagement>
         <dependencies>
             <dependency>


### PR DESCRIPTION
*Issue #, if available:*

Removing DynamoDBLocal Repo to s3 (Default should Maven central)

*Description of changes:*

DynamoDB Local team does not publish any new changes to Maven S3 Repo going forward, since migrating to Maven Central. 

Hence removing the reference to S3 repo, it will fallback to Maven Central Repo.

https://mvnrepository.com/artifact/com.amazonaws/DynamoDBLocal


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
