### PR TITLE
fix: failing tests due to dependency issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,13 @@
             <version>${aws.dynamodblocal.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.32</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </licenses>
 
     <properties>
-        <aws-java-sdk.version>1.12.130</aws-java-sdk.version>
+        <aws-java-sdk.version>1.12.710</aws-java-sdk.version>
         <amazon-kinesis-client.version>1.14.9</amazon-kinesis-client.version>
         <powermock.version>1.6.2</powermock.version>
         <aws.dynamodblocal.version>[1.12,2.0)</aws.dynamodblocal.version>


### PR DESCRIPTION
*Issue #, if available:*
No existing issue.

*Description of changes:*
 - Bump `aws-java-sdk` from `1.12.130` to `1.12.710` to fix failing tests due to missing method (getDeletionProtectionEnabled()) in DynamoDBLocal.
 - Add Lombok as provided dependency.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
