### PR TITLE
bump awssdk.dynamodb version from 2.32.0 to 2.39.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <software-kinesis.version>3.1.1</software-kinesis.version>
         <gpg.skip>true</gpg.skip>
         <maven.dependency.version>3.0.0</maven.dependency.version>
-        <awssdk.version>2.32.33</awssdk.version>
+        <awssdk.version>2.39.6</awssdk.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This PR bumps the version for `software.amazon.awssdk » dynamodb` from `v2.32.0` to `v2.32.33` to fix the vulnerabilities introduced due to its transitive dependencies.

Here is a log of vulnerabilities reporter when using `dynamodb-streams-kinesis-adapter` `v2.0.1` by snyk:
```
  Upgrade software.amazon.awssdk:dynamodb@2.32.0 to software.amazon.awssdk:dynamodb@2.32.33 to fix
  ✗ Stack-based Buffer Overflow [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-10500754] in com.fasterxml.jackson.core:jackson-core@2.14.3
    introduced by software.amazon.awssdk:dynamodb@2.32.0 > com.fasterxml.jackson.core:jackson-core@2.14.3
  ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-7569538] in com.fasterxml.jackson.core:jackson-core@2.14.3
    introduced by software.amazon.awssdk:dynamodb@2.32.0 > com.fasterxml.jackson.core:jackson-core@2.14.3
  ✗ Allocation of Resources Without Limits or Throttling [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-11799531] in io.netty:netty-codec-http2@4.1.118.Final
    introduced by software.amazon.awssdk:dynamodb@2.32.0 > io.netty:netty-codec-http2@4.1.118.Final
  ✗ Improper Handling of Highly Compressed Data (Data Amplification) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-12485151] in io.netty:netty-codec-http2@4.1.118.Final
    introduced by software.amazon.awssdk:dynamodb@2.32.0 > io.netty:netty-codec-http2@4.1.118.Final
  ✗ HTTP Request Smuggling [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-12485149] in io.netty:netty-codec-http@4.1.118.Final
    introduced by software.amazon.awssdk:dynamodb@2.32.0 > io.netty:netty-codec-http@4.1.118.Final
  ✗ Improper Handling of Highly Compressed Data (Data Amplification) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-12485150] in io.netty:netty-codec-http@4.1.118.Final
    introduced by software.amazon.awssdk:dynamodb@2.32.0 > io.netty:netty-codec-http@4.1.118.Final
  ✗ Uncontrolled Recursion [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-10734078] in org.apache.commons:commons-lang3@3.14.0
    introduced by software.amazon.awssdk:dynamodb@2.32.0 > org.apache.commons:commons-lang3@3.14.0
```
