### PR TITLE
Optimizing clean up process and removing 6hrs retention period check

### DIFF
--- a/src/main/java/com/amazonaws/services/dynamodbv2/streamsadapter/DynamoDBStreamsShardDetector.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/streamsadapter/DynamoDBStreamsShardDetector.java
@@ -26,6 +26,7 @@ import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.core.ApiName;
+import software.amazon.awssdk.services.dynamodb.model.ShardFilterType;
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
 import software.amazon.awssdk.services.kinesis.model.DescribeStreamRequest;
 import software.amazon.awssdk.services.kinesis.model.DescribeStreamResponse;
@@ -34,6 +35,7 @@ import software.amazon.awssdk.services.kinesis.model.LimitExceededException;
 import software.amazon.awssdk.services.kinesis.model.ResourceInUseException;
 import software.amazon.awssdk.services.kinesis.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.kinesis.model.Shard;
+import software.amazon.awssdk.services.kinesis.model.ShardFilter;
 import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.kinesis.common.StreamIdentifier;
 import software.amazon.kinesis.leases.ShardDetector;
@@ -195,6 +197,37 @@ public class DynamoDBStreamsShardDetector implements ShardDetector {
         return describeStreamResult.getShards();
     }
 
+    @Override
+    public List<Shard> listShardsWithFilter(ShardFilter shardFilter, String consumerId) {
+        try {
+            AmazonDynamoDBStreamsAdapterClient dynamoDBStreamsAdapterClient;
+            if (this.kinesisAsyncClient instanceof  AmazonDynamoDBStreamsAdapterClient){
+                dynamoDBStreamsAdapterClient = (AmazonDynamoDBStreamsAdapterClient) this.kinesisAsyncClient;
+                DescribeStreamResponse describeStreamResponse = dynamoDBStreamsAdapterClient.describeStreamWithFilter(
+                        streamArn,
+                        software.amazon.awssdk.services.dynamodb.model.ShardFilter.builder()
+                                .type(shardFilter.typeAsString())
+                                .shardId(shardFilter.shardId())
+                                .build(),
+                        consumerId);
+                log.debug("Fetched childShards for shard: " + shardFilter.shardId() + " Number of childShards are: "
+                        + describeStreamResponse.streamDescription().shards().size());
+                return describeStreamResponse.streamDescription().shards();
+            }
+        } catch (ResourceNotFoundException e) {
+            log.error("Shard not found during child-shard discovery for stream and shard: {}:{}",
+                    streamArn, shardFilter.shardId(), e);
+        } catch (LimitExceededException e) {
+            log.error("Caught limit exceeded exception while getting child shards for stream and shard: {}:{}",
+                    streamArn, shardFilter.shardId(), e);
+        } catch (Exception e) {
+            // if there is any exception, fall back to paginated DescribeStream call for shard discovery
+            log.error("Caught exception while getting child shards from stream and shard: {}:{}",
+                    streamArn, shardFilter.shardId(), e);
+        }
+        return null;
+    }
+
     @Synchronized
     public DescribeStreamResult describeStream(String lastSeenShardId, String consumerId) {
         ShardGraphTracker shardTracker = new ShardGraphTracker();
@@ -264,7 +297,6 @@ public class DynamoDBStreamsShardDetector implements ShardDetector {
         if (describeStreamResponse == null) {
             throw new IllegalStateException("Received null from DescribeStream call.");
         }
-
         return describeStreamResponse;
     }
 

--- a/src/main/java/com/amazonaws/services/dynamodbv2/streamsadapter/DynamoDBStreamsShardSyncer.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/streamsadapter/DynamoDBStreamsShardSyncer.java
@@ -14,8 +14,6 @@
  */
 package com.amazonaws.services.dynamodbv2.streamsadapter;
 
-import static com.amazonaws.services.dynamodbv2.streamsadapter.util.KinesisMapperUtil.MIN_LEASE_RETENTION_DURATION_IN_HOURS;
-import static com.amazonaws.services.dynamodbv2.streamsadapter.util.KinesisMapperUtil.getShardCreationTime;
 import static software.amazon.kinesis.common.HashKeyRangeForLease.fromHashKeyRange;
 import static java.util.Objects.nonNull;
 
@@ -32,6 +30,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import software.amazon.awssdk.services.kinesis.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.kinesis.model.Shard;
+import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.kinesis.common.InitialPositionInStream;
 import software.amazon.kinesis.common.InitialPositionInStreamExtended;
 import software.amazon.kinesis.common.StreamIdentifier;
@@ -43,6 +42,7 @@ import software.amazon.kinesis.leases.Lease;
 import software.amazon.kinesis.leases.LeaseRefresher;
 import software.amazon.kinesis.leases.MultiStreamLease;
 import software.amazon.kinesis.leases.ShardDetector;
+import software.amazon.kinesis.leases.UpdateField;
 import software.amazon.kinesis.leases.exceptions.DependencyException;
 import software.amazon.kinesis.leases.exceptions.InvalidStateException;
 import software.amazon.kinesis.leases.exceptions.ProvisionedThroughputException;
@@ -52,7 +52,6 @@ import software.amazon.kinesis.metrics.MetricsUtil;
 import software.amazon.kinesis.retrieval.kpl.ExtendedSequenceNumber;
 import java.io.Serializable;
 import java.math.BigInteger;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -242,10 +241,12 @@ public class DynamoDBStreamsShardSyncer extends HierarchicalShardSyncer {
             trackedLeases.addAll(currentLeases);
         }
         trackedLeases.addAll(newLeasesToCreate);
-        cleanupGarbageLeases(shards, trackedLeases, shardDetector, leaseRefresher, multiStreamArgs);
+        LOG.info("syncShardLeases " + streamArn  + ": cleanup begins");
+        Map<String, Lease> deletedLeases = cleanupGarbageLeases(shards, trackedLeases, shardDetector, leaseRefresher,
+                multiStreamArgs);
         if (cleanupLeasesOfCompletedShards) {
-            cleanupLeasesOfFinishedShards(currentLeases, shardIdToShardMap, shardIdToChildShardIdsMap,
-                    trackedLeases, leaseRefresher, multiStreamArgs);
+            cleanupLeasesOfFinishedShards(currentLeases, shardIdToShardMap, shardIdToChildShardIdsMap, trackedLeases,
+                    deletedLeases, leaseRefresher, multiStreamArgs);
         }
         MetricsUtil.addLatency(scope, "ShardSyncLatency:" + streamArn, startTimeMillis, MetricsLevel.SUMMARY);
         LOG.info("syncShardLeases: " + streamArn  + ": end");
@@ -506,7 +507,7 @@ public class DynamoDBStreamsShardSyncer extends HierarchicalShardSyncer {
         return isDescendant;
     }
 
-    private void cleanupGarbageLeases(List<Shard> shards,
+    private Map<String, Lease> cleanupGarbageLeases(List<Shard> shards,
                                       List<Lease> trackedLeases,
                                       ShardDetector shardDetector,
                                       LeaseRefresher leaseRefresher,
@@ -551,6 +552,10 @@ public class DynamoDBStreamsShardSyncer extends HierarchicalShardSyncer {
             }
         }
         LOG.info("cleanupGarbageLeases " + streamArn + ": done");
+        return garbageLeases.stream()
+                .collect(Collectors.toMap(
+                        lease -> SHARD_ID_FROM_LEASE_DEDUCER.apply(lease, multiStreamArgs),
+                        lease -> lease));
     }
 
     /**
@@ -565,6 +570,7 @@ public class DynamoDBStreamsShardSyncer extends HierarchicalShardSyncer {
      * @param shardIdToChildShardIdsMap Map of shardId->childShardIds (assumed to include all Kinesis shards)
      * @param trackedLeases List of all leases we are tracking.
      * @param leaseRefresher Lease manager (will be used to delete leases)
+     * @param deletedLeases Map of leaseKey -> Lease of deleted leases for tracking.
      * @throws DependencyException
      * @throws InvalidStateException
      * @throws ProvisionedThroughputException
@@ -574,6 +580,7 @@ public class DynamoDBStreamsShardSyncer extends HierarchicalShardSyncer {
                                                             Map<String, Shard> shardIdToShardMap,
                                                             Map<String, Set<String>> shardIdToChildShardIdsMap,
                                                             List<Lease> trackedLeases,
+                                                            Map<String, Lease> deletedLeases,
                                                             LeaseRefresher leaseRefresher,
                                                             MultiStreamArgs multiStreamArgs)
             throws DependencyException, InvalidStateException, ProvisionedThroughputException {
@@ -595,12 +602,14 @@ public class DynamoDBStreamsShardSyncer extends HierarchicalShardSyncer {
                     = new StartingSequenceNumberAndShardIdBasedComparator(shardIdToShardMap, multiStreamArgs);
             leasesOfClosedShards.sort(startingSequenceNumberComparator);
             Map<String, Lease> trackedLeaseMap = constructShardIdToKCLLeaseMap(trackedLeases, multiStreamArgs);
-
+            LOG.info("cleanupLeasesOfFinishedShards " + streamArn + ": Found closed shards to clean: "
+                    + leasesOfClosedShards.size() );
             for (Lease leaseOfClosedShard : leasesOfClosedShards) {
                 String closedShardId = SHARD_ID_FROM_LEASE_DEDUCER.apply(leaseOfClosedShard, multiStreamArgs);
                 Set<String> childShardIds = shardIdToChildShardIdsMap.get(closedShardId);
                 if ((closedShardId != null) && (childShardIds != null) && (!childShardIds.isEmpty())) {
-                    cleanupLeaseForClosedShard(closedShardId, childShardIds, trackedLeaseMap, leaseRefresher,
+                    LOG.info("cleanupLeasesOfFinishedShards Found closed shard to clean: " + closedShardId );
+                    cleanupLeaseForClosedShard(closedShardId, trackedLeaseMap, deletedLeases, leaseRefresher,
                             multiStreamArgs);
                 }
             }
@@ -611,65 +620,73 @@ public class DynamoDBStreamsShardSyncer extends HierarchicalShardSyncer {
     /**
      * Delete lease for the closed shard. Rules for deletion are:
      * a/ the checkpoint for the closed shard is SHARD_END,
-     * b/ there are leases for all the childShardIds and their checkpoint is also SHARD_END
-     * c/ the shard has existed longer than the minimum lease retention duration (6 hours)
-     *The lease retention duration ensures that we don't prematurely delete leases for shards
-     *that might still be needed for stream position recovery
+     * b/ the lease contains child-shard IDs (populated during shard-end processing),
+     * c/ there are leases for all the childShardIds and they have begun/finished processing
+     *    i.e. their checkpoint is not TRIM_HORIZON,
+     * d/ all parent shard leases have been deleted first (parent-before-child ordering).
+     *
      * Note: This method has package level access solely for testing purposes.
      *
      * @param closedShardId Identifies the closed shard
-     * @param childShardIds ShardIds of children of the closed shard
      * @param trackedLeases shardId->KinesisClientLease map with all leases we are tracking (should not be null)
+     * @param deletedLeases Map of leaseKey -> deleted leases for tracking deletion ordering within the same sync cycle.
      * @param leaseRefresher
      * @throws ProvisionedThroughputException
      * @throws InvalidStateException
      * @throws DependencyException
      */
     synchronized void cleanupLeaseForClosedShard(String closedShardId,
-                                                 Set<String> childShardIds,
                                                  Map<String, Lease> trackedLeases,
+                                                 Map<String, Lease> deletedLeases,
                                                  LeaseRefresher leaseRefresher,
                                                  MultiStreamArgs multiStreamArgs)
             throws DependencyException, InvalidStateException, ProvisionedThroughputException {
         Lease leaseForClosedShard = trackedLeases.get(closedShardId);
+        if  (leaseForClosedShard == null) return;
         List<Lease> childShardLeases = new ArrayList<>();
-
+        Set<String> childShardIds = leaseForClosedShard.childShardIds();
+        if (childShardIds == null || childShardIds.isEmpty()) {
+            LOG.info("cleanupLeasesOfFinishedShards ChildShards not found for closed shard to clean: " + closedShardId);
+            return;
+        }
         for (String childShardId : childShardIds) {
             Lease childLease = trackedLeases.get(childShardId);
             if (childLease != null) {
                 childShardLeases.add(childLease);
             }
         }
-
-        if ((leaseForClosedShard != null)
-                && (leaseForClosedShard.checkpoint().equals(ExtendedSequenceNumber.SHARD_END))
+        if (leaseForClosedShard.checkpoint().equals(ExtendedSequenceNumber.SHARD_END)
                 && (childShardLeases.size() == childShardIds.size())) {
             boolean okayToDelete = true;
             for (Lease lease : childShardLeases) {
-                if (!lease.checkpoint().equals(ExtendedSequenceNumber.SHARD_END)) {
+                if (lease.checkpoint().equals(ExtendedSequenceNumber.TRIM_HORIZON)) {
                     okayToDelete = false; // if any child is still being processed, don't delete lease for parent
                     break;
                 }
             }
-
-            try {
-                if (Instant.now().isBefore(getShardCreationTime(closedShardId)
-                        .plus(MIN_LEASE_RETENTION_DURATION_IN_HOURS))) {
-                    // if parent was created within lease retention period, don't delete lease for parent
-                    okayToDelete = false;
+            // if parent lease still exists then the lease will not be cleaned.
+            Set<String> parentShardIdsOfClosedLease = leaseForClosedShard.parentShardIds();
+            if (!CollectionUtils.isNullOrEmpty(parentShardIdsOfClosedLease)) {
+                for (String parentShardIdOfClosedLease : parentShardIdsOfClosedLease) {
+                    Lease parentLeaseInTable = trackedLeases.get(parentShardIdOfClosedLease);
+                    Lease parentLeaseInDeletedList = deletedLeases.get(parentShardIdOfClosedLease);
+                    if (parentLeaseInTable != null && parentLeaseInDeletedList == null) {
+                        LOG.info("parent lease " + parentShardIdOfClosedLease + " should be cleaned up before " +
+                                "child lease " + closedShardId);
+                        okayToDelete = false; // parent should be cleaned before child lease
+                        break;
+                    }
                 }
-            } catch (RuntimeException e) {
-                LOG.info("Could not extract creation time from ShardId [" + closedShardId + "] " + streamArn);
-                LOG.debug(e);
             }
 
             if (okayToDelete) {
                 LOG.info("Deleting lease for shard " + SHARD_ID_FROM_LEASE_DEDUCER.apply(leaseForClosedShard,
                         multiStreamArgs) + " as it is eligible for cleanup - its child shard is check-pointed at "
-                        + "SHARD_END for the stream "
+                        + leaseForClosedShard.checkpoint() + " for the stream "
                         + streamArn
                 );
                 leaseRefresher.deleteLease(leaseForClosedShard);
+                deletedLeases.put(closedShardId, leaseForClosedShard);
             }
         }
     }
@@ -697,18 +714,10 @@ public class DynamoDBStreamsShardSyncer extends HierarchicalShardSyncer {
      */
     synchronized void assertClosedShardsAreCoveredOrAbsent(Map<String, Shard> shardIdToShardMap,
                                                            Map<String, Set<String>> shardIdToChildShardIdsMap,
-                                                           Set<String> shardIdsOfClosedShards) throws
-            KinesisClientLibIOException {
-        String exceptionMessageSuffix = "This can happen if we constructed the list of shards "
-                + " while a reshard operation was in progress.";
+                                                           Set<String> shardIdsOfClosedShards) {
 
         for (String shardId : shardIdsOfClosedShards) {
             Shard shard = shardIdToShardMap.get(shardId);
-            if (Instant.now().isBefore(getShardCreationTime(shardId).plus(MIN_LEASE_RETENTION_DURATION_IN_HOURS))) {
-                LOG.info("Delaying deleting Shard " + shardId + " till lease retention duration is reached. "
-                        + streamArn);
-                continue; // if parent was created within lease retention period, don't delete lease for parent
-            }
             if (shard == null) {
                 LOG.info("Shard " + shardId + " is not present in stream " + streamArn + "anymore.");
                 continue;
@@ -716,14 +725,13 @@ public class DynamoDBStreamsShardSyncer extends HierarchicalShardSyncer {
 
             String endingSequenceNumber = shard.sequenceNumberRange().endingSequenceNumber();
             if (endingSequenceNumber == null) {
-                throw new KinesisClientLibIOException("Shard " + shardId
-                        + " is not closed. " + exceptionMessageSuffix);
+                shardIdToChildShardIdsMap.remove(shardId);
+                continue;
             }
 
             Set<String> childShardIds = shardIdToChildShardIdsMap.get(shardId);
             if (childShardIds == null) {
-                throw new KinesisClientLibIOException("Incomplete shard list: Closed shard " + shardId
-                        + " has no children." + exceptionMessageSuffix);
+                shardIdToChildShardIdsMap.remove(shardId);
             }
         }
     }

--- a/src/main/java/com/amazonaws/services/dynamodbv2/streamsadapter/tasks/DynamoDBStreamsShutdownTask.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/streamsadapter/tasks/DynamoDBStreamsShutdownTask.java
@@ -18,7 +18,10 @@ import com.amazonaws.services.dynamodbv2.streamsadapter.util.KinesisMapperUtil;
 import com.google.common.annotations.VisibleForTesting;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.services.dynamodb.model.ShardFilterType;
 import software.amazon.awssdk.services.kinesis.model.ChildShard;
+import software.amazon.awssdk.services.kinesis.model.Shard;
+import software.amazon.awssdk.services.kinesis.model.ShardFilter;
 import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.kinesis.checkpoint.ShardRecordProcessorCheckpointer;
 import software.amazon.kinesis.common.InitialPositionInStreamExtended;
@@ -28,6 +31,7 @@ import software.amazon.kinesis.leases.Lease;
 import software.amazon.kinesis.leases.LeaseCleanupManager;
 import software.amazon.kinesis.leases.LeaseCoordinator;
 import software.amazon.kinesis.leases.LeaseRefresher;
+import software.amazon.kinesis.leases.MultiStreamLease;
 import software.amazon.kinesis.leases.ShardDetector;
 import software.amazon.kinesis.leases.ShardInfo;
 import software.amazon.kinesis.leases.UpdateField;
@@ -231,8 +235,64 @@ public class DynamoDBStreamsShutdownTask implements ConsumerTask {
         if (!CollectionUtils.isNullOrEmpty(childShards)) {
             createLeasesForChildShardsIfNotExist(scope);
             updateLeaseWithChildShards(currentShardLease);
+            log.debug("Child leases created when shard {} reached its end", leaseKey);
         }
         attemptShardEndCheckpointing(leaseKey, scope, startTime);
+
+        // At this point, child lease has already been created for uninterrupted data processing.
+        // Now backfill child-shard-ids to fulfil cleanup conditions.
+        fetchChildShardsForCompleteLineage(currentShardLease);
+    }
+
+
+    /**
+     * Backfills child-shard-ids in ancestor leases that are missing them. This handles cases where
+     * child-shard-ids were not populated during shard-end processing — for example, when migrating
+     * from KCLv1 to KCLv3, or lease update with child-shard-ids failed.
+     * This method walks up the parent chain recursively, to fetch and persist
+     * child-shard-ids for each parent lease, until it encounters a parent that already has
+     * child-shard-ids populated or has no further parent leases.
+     *
+     * @param currentShardLease the lease whose parent lineage will be backfilled with child-shard-ids
+     */
+    private void fetchChildShardsForCompleteLineage(Lease currentShardLease) {
+        Set<String> parentShardIds = currentShardLease.parentShardIds();
+        if (parentShardIds == null || parentShardIds.isEmpty()) {
+            return;
+        }
+        for (String parentShardId : parentShardIds) {
+            try {
+                String parentLeaseKey = currentShardLease instanceof MultiStreamLease
+                        ? MultiStreamLease.getLeaseKey(((MultiStreamLease) currentShardLease).streamIdentifier(),
+                        parentShardId)
+                        : parentShardId;
+                Lease parentLease = leaseCoordinator.leaseRefresher().getLease(parentLeaseKey);
+                if (parentLease == null) {
+                    continue;
+                }
+                if (!CollectionUtils.isNullOrEmpty(parentLease.childShardIds())) {
+                    continue; // already backfilled, lineage above is complete
+                }
+                ShardFilter shardFilter = ShardFilter.builder()
+                        .type(ShardFilterType.CHILD_SHARDS.toString())
+                        .shardId(parentShardId)
+                        .build();
+                List<Shard> fetchedChildShards = dynamoDBStreamsShardDetector.listShardsWithFilter(
+                        shardFilter, leaseCoordinator.leaseRefresher().getLeaseTableIdentifier());
+                if (fetchedChildShards != null && !fetchedChildShards.isEmpty()) {
+                    Set<String> childShardIds = fetchedChildShards.stream()
+                            .map(Shard::shardId)
+                            .collect(Collectors.toSet());
+                    Lease updatedLease = parentLease.copy();
+                    updatedLease.childShardIds(childShardIds);
+                    leaseCoordinator.leaseRefresher().updateLeaseWithMetaInfo(updatedLease, UpdateField.CHILD_SHARDS);
+                    log.info("Updated parent lease {} with child shard ids: {}", parentShardId, childShardIds);
+                }
+                fetchChildShardsForCompleteLineage(parentLease);
+            } catch (Exception e) {
+                log.error("Error in lineage completion for parent shard {}", parentShardId, e);
+            }
+        }
     }
 
     private boolean attemptShardEndCheckpointing(final String leaseKey, MetricsScope scope, long startTime)

--- a/src/main/java/com/amazonaws/services/dynamodbv2/streamsadapter/util/StreamsLeaseCleanupValidator.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/streamsadapter/util/StreamsLeaseCleanupValidator.java
@@ -14,9 +14,6 @@
  */
 package com.amazonaws.services.dynamodbv2.streamsadapter.util;
 
-import static com.amazonaws.services.dynamodbv2.streamsadapter.util.KinesisMapperUtil.MIN_LEASE_RETENTION_DURATION_IN_HOURS;
-import static com.amazonaws.services.dynamodbv2.streamsadapter.util.KinesisMapperUtil.getShardCreationTime;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import software.amazon.kinesis.exceptions.internal.KinesisClientLibIOException;
@@ -58,24 +55,18 @@ public final class StreamsLeaseCleanupValidator {
             shardId = lease.leaseKey();
         }
 
-        // During child shard discovery, there might be leases which are found in child shard but describestream
-        // hasn't yet returned them, dont mark a lease as candidate for cleanup if its a new lease
-        if (Instant.now().isBefore(getShardCreationTime(shardId).plus(MIN_LEASE_RETENTION_DURATION_IN_HOURS))) {
-            return false;
-        }
-
         if (currentKinesisShardIds.contains(shardId)) {
             isCandidateForCleanup = false;
         } else {
             LOG.info(String.format("Found lease for non-existent shard: %s. Checking its parent shards", shardId));
             Set<String> parentShardIds = lease.parentShardIds();
             for (String parentShardId : parentShardIds) {
-                // Throw an exception if the parent shard exists (but the child does not).
+                // Return false if parent shard exists (but the child does not).
                 // This may be a (rare) race condition between fetching the shard list and Kinesis expiring shards.
                 if (currentKinesisShardIds.contains(parentShardId)) {
                     String message = "Parent shard " + parentShardId + " exists but not the child shard " + shardId;
-                    LOG.info(message);
-                    throw new KinesisClientLibIOException(message);
+                    LOG.error(message);
+                    return false;
                 }
             }
         }

--- a/src/test/java/com/amazonaws/services/dynamodbv2/streamsadapter/DynamoDBStreamsShardSyncerTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/streamsadapter/DynamoDBStreamsShardSyncerTest.java
@@ -905,13 +905,18 @@ public class DynamoDBStreamsShardSyncerTest {
 
         List<Shard> currentShards = Arrays.asList(grandparent, parent, child1, child2, independent);
 
+        Set<String> childShardIds = new HashSet<>();
+        childShardIds.add(child1ShardId);
+        childShardIds.add(child2ShardId);
+
         // Setup existing leases in the lease table
         // 1. Active shard lease from current stream
         MultiStreamLease currentActiveLease = createTestLease(
                 currentStreamName,
                 child1ShardId,
                 ExtendedSequenceNumber.TRIM_HORIZON,
-                parentShardId
+                parentShardId,
+                childShardIds
         );
 
         // 2. Stale shard lease from current stream (should be deleted)
@@ -919,6 +924,7 @@ public class DynamoDBStreamsShardSyncerTest {
                 currentStreamName,
                 staleShardId,
                 ExtendedSequenceNumber.SHARD_END,
+                null,
                 null
         );
 
@@ -927,6 +933,7 @@ public class DynamoDBStreamsShardSyncerTest {
                 otherStreamName,
                 "shardId-000000000000000000007-other",
                 ExtendedSequenceNumber.TRIM_HORIZON,
+                null,
                 null
         );
 
@@ -980,25 +987,35 @@ public class DynamoDBStreamsShardSyncerTest {
         Shard grandChild2 = createTestShard(grandChild2ShardId, child2ShardId, null, "201", null);  // open
         List<Shard> currentShards = Arrays.asList(parent, child1, child2, grandChild1, grandChild2);
 
+        Set<String> childShardIds = new HashSet<>();
+        childShardIds.add(child1ShardId);
+        childShardIds.add(child2ShardId);
         // Setup leases for stream1 (current stream)
         // Parent lease - completed
         Lease parentLease = createCompletedLease(
                 MULTI_STREAM_NAME,
                 parentShardId,
-                null  // no parent
+                null,  // no parent,
+                childShardIds
         );
 
+        Set<String> grandChildIds = new HashSet<>();
+        grandChildIds.add(grandChild1ShardId);
         // Child leases - both completed
         Lease child1Lease = createCompletedLease(
                 MULTI_STREAM_NAME,
                 child1ShardId,
-                parentShardId
+                parentShardId,
+                grandChildIds
         );
+        grandChildIds.remove(grandChild1ShardId);
+        grandChildIds.add(grandChild2ShardId);
 
         Lease child2Lease = createCompletedLease(
                 MULTI_STREAM_NAME,
                 child2ShardId,
-                parentShardId
+                parentShardId,
+                grandChildIds
         );
 
         // Grandchild leases - both active at TRIM_HORIZON
@@ -1006,14 +1023,16 @@ public class DynamoDBStreamsShardSyncerTest {
                 MULTI_STREAM_NAME,
                 grandChild1ShardId,
                 ExtendedSequenceNumber.TRIM_HORIZON,  // active lease
-                child1ShardId
+                child1ShardId,
+                null
         );
 
         Lease grandChild2Lease = createTestLease(
                 MULTI_STREAM_NAME,
                 grandChild2ShardId,
-                ExtendedSequenceNumber.TRIM_HORIZON,  // active lease
-                child2ShardId
+                ExtendedSequenceNumber.SHARD_END,  // active lease
+                child2ShardId,
+                null
         );
 
         // Setup current stream leases
@@ -1049,9 +1068,10 @@ public class DynamoDBStreamsShardSyncerTest {
         // Should delete parent lease since all its children are at SHARD_END and have active children
         verify(leaseRefresher).deleteLease(parentLease);
 
-        // Should NOT delete child leases since they have active children
+        // Should not delete child leases since they have children with seq number at TRIM_HORIZON
         verify(leaseRefresher, never()).deleteLease(child1Lease);
-        verify(leaseRefresher, never()).deleteLease(child2Lease);
+        // Should delete child leases since they have children with seq number at SHARD_END
+        verify(leaseRefresher, times(1)).deleteLease(child2Lease);
 
         // Should NOT delete grandchild leases since they're active
         verify(leaseRefresher, never()).deleteLease(grandChild1Lease);
@@ -1100,25 +1120,41 @@ public class DynamoDBStreamsShardSyncerTest {
                 childShard1, childShard2, childShard3, childShard4
         );
 
+        Set<String> grandParentChildShardIds = new HashSet<>();
+        grandParentChildShardIds.add(parentShardId1);
+        grandParentChildShardIds.add(parentShardId2);
+
         // Setup leases
         // Grandparent lease - completed
         MultiStreamLease grandparentLease = createCompletedLease(
                 streamName,
                 grandparentShardId,
-                null  // no parent
+                null,  // no parent
+                grandParentChildShardIds
         );
+
+        Set<String> childShardIds = new HashSet<>();
+        childShardIds.add(childShardId1);
+        childShardIds.add(childShardId2);
 
         // Parent leases - all completed
         MultiStreamLease parentLease1 = createCompletedLease(
                 streamName,
                 parentShardId1,
-                grandparentShardId
+                grandparentShardId,
+                childShardIds
         );
+
+        childShardIds.remove(childShardId1);
+        childShardIds.remove(childShardId2);
+        childShardIds.add(childShardId3);
+        childShardIds.add(childShardId4);
 
         MultiStreamLease parentLease2 = createCompletedLease(
                 streamName,
                 parentShardId2,
-                grandparentShardId
+                grandparentShardId,
+                childShardIds
         );
 
         // Child leases - all still active
@@ -1182,21 +1218,20 @@ public class DynamoDBStreamsShardSyncerTest {
         assertTrue(result);
 
         // Verify lease deletion behavior
-        // Grandparent lease should not be deleted because:
-        // 1. It's too recent (30 minutes < 6 hours)
-        // 2. Its children (parents) are still being processed
-        verify(leaseRefresher, never()).deleteLease(grandparentLease);
+        // Grandparent lease should be deleted because:
+        // 1. processing of the lease is over and,
+        // 2. Its children (parents) have begun processing
+        verify(leaseRefresher, times(1)).deleteLease(grandparentLease);
 
-        // Parent leases should not be deleted because:
-        // 1. They're even more recent than grandparent
-        // 2. Their children (leaf nodes) are still being processed
-        verify(leaseRefresher, never()).deleteLease(parentLease1);
-        verify(leaseRefresher, never()).deleteLease(parentLease2);
+        // Parent leases should be deleted because:
+        // 1. processing of the lease is over and,
+        // 2. Their children (leaf nodes) have begun processing
+        verify(leaseRefresher, times(1)).deleteLease(parentLease1);
+        verify(leaseRefresher, times(1)).deleteLease(parentLease2);
 
         // Child leases should not be deleted because:
-        // 1. They're the most recent
-        // 2. They're still actively processing (not at SHARD_END)
-        // 3. They're open shards (no ending sequence number)
+        // 1. They're still actively processing (not at SHARD_END)
+        // 2. They're open shards (no ending sequence number)
         verify(leaseRefresher, never()).deleteLease(childLease1);
         verify(leaseRefresher, never()).deleteLease(childLease2);
         verify(leaseRefresher, never()).deleteLease(childLease3);
@@ -1236,25 +1271,41 @@ public class DynamoDBStreamsShardSyncerTest {
                 childShard1, childShard2, childShard3, childShard4
         );
 
+        Set<String> grandParentChildShardIds = new HashSet<>();
+        grandParentChildShardIds.add(parentShardId1);
+        grandParentChildShardIds.add(parentShardId2);
+
         // Setup leases
         // Grandparent lease - old and completed
         MultiStreamLease grandparentLease = createCompletedLease(
                 MULTI_STREAM_NAME,
                 grandparentShardId,
-                null  // no parent
+                null,  // no parent
+                grandParentChildShardIds
         );
+
+        Set<String> childShardIds = new HashSet<>();
+        childShardIds.add(childShardId1);
+        childShardIds.add(childShardId2);
 
         // Parent leases - all completed but not old enough
         MultiStreamLease parentLease1 = createCompletedLease(
                 MULTI_STREAM_NAME,
                 parentShardId1,
-                grandparentShardId
+                grandparentShardId,
+                childShardIds
         );
+
+        childShardIds.remove(childShardId1);
+        childShardIds.remove(childShardId2);
+        childShardIds.add(childShardId3);
+        childShardIds.add(childShardId4);
 
         MultiStreamLease parentLease2 = createCompletedLease(
                 MULTI_STREAM_NAME,
                 parentShardId2,
-                grandparentShardId
+                grandparentShardId,
+                childShardIds
         );
 
         // Child leases - still active
@@ -1318,18 +1369,17 @@ public class DynamoDBStreamsShardSyncerTest {
         assertTrue(result);
 
         // Verify only grandparent lease is deleted because:
-        // 1. It's old enough (7 hours > 6 hours)
+        // 1. Lease processing is complete and
         // 2. All its children (parents) are at SHARD_END
         verify(leaseRefresher, times(1)).deleteLease(grandparentLease);
 
-        // Parent leases should not be deleted because they're not old enough
-        verify(leaseRefresher, never()).deleteLease(parentLease1);
-        verify(leaseRefresher, never()).deleteLease(parentLease2);
+        // Parent leases should be deleted because lease processing is complete
+        verify(leaseRefresher, times(1)).deleteLease(parentLease1);
+        verify(leaseRefresher, times(1)).deleteLease(parentLease2);
 
         // Child leases should not be deleted because:
-        // 1. They're recent
-        // 2. They're still processing (not at SHARD_END)
-        // 3. They're open shards
+        // 1. They're still processing (not at SHARD_END)
+        // 2. They're open shards
         verify(leaseRefresher, never()).deleteLease(childLease1);
         verify(leaseRefresher, never()).deleteLease(childLease2);
         verify(leaseRefresher, never()).deleteLease(childLease3);
@@ -1369,19 +1419,29 @@ public class DynamoDBStreamsShardSyncerTest {
                 childShard1, childShard2, childShard3, childShard4
         );
 
+        Set<String> grandParentChildShardIds = new HashSet<>();
+        grandParentChildShardIds.add(parentShardId1);
+        grandParentChildShardIds.add(parentShardId2);
+
         // Setup leases
         // Grandparent lease - old enough but won't be deleted due to active child
         MultiStreamLease grandparentLease = createCompletedLease(
                 MULTI_STREAM_NAME,
                 grandparentShardId,
-                null  // no parent
+                null,  // no parent
+                grandParentChildShardIds
         );
+
+        Set<String> childShardIds = new HashSet<>();
+        childShardIds.add(childShardId1);
+        childShardIds.add(childShardId2);
 
         // Parent leases - one completed, one still processing
         MultiStreamLease parentLease1 = createCompletedLease(
                 MULTI_STREAM_NAME,
                 parentShardId1,
-                grandparentShardId
+                grandparentShardId,
+                childShardIds
         );
 
         MultiStreamLease parentLease2 = createActiveLease(
@@ -1452,13 +1512,14 @@ public class DynamoDBStreamsShardSyncerTest {
 
         assertTrue(result);
 
-        // Verify grandparent lease is NOT deleted because:
-        // 1. Although it's old enough (7 hours > 6 hours)
-        // 2. One of its children (parentLease2) is still processing
-        verify(leaseRefresher, never()).deleteLease(grandparentLease);
+        // Verify grandparent lease is deleted because:
+        // 1. processing is complete and
+        // 2. One of its children (parentLease2) is being processed
+        verify(leaseRefresher, times(1)).deleteLease(grandparentLease);
 
-        // Parent leases should not be deleted
-        verify(leaseRefresher, never()).deleteLease(parentLease1);  // Not old enough
+        // Parent leases should be deleted as the lease is completed
+        verify(leaseRefresher, times(1)).deleteLease(parentLease1);  // Not old enough
+        // Parent leases should be deleted as it is active lease
         verify(leaseRefresher, never()).deleteLease(parentLease2);  // Still processing
 
         // Child leases should not be deleted
@@ -1468,7 +1529,7 @@ public class DynamoDBStreamsShardSyncerTest {
         verify(leaseRefresher, never()).deleteLease(childLease4);
 
         // Additional verification that no other leases were deleted
-        verify(leaseRefresher, never()).deleteLease(any());
+        verify(leaseRefresher, times(2)).deleteLease(any());
     }
     
     /**
@@ -1493,25 +1554,32 @@ public class DynamoDBStreamsShardSyncerTest {
 
         List<Shard> currentShards = Arrays.asList(parentShard, childShard1, childShard2);
 
+        Set<String> childShardIds = new HashSet<>();
+        childShardIds.add(childShardId1);
+        childShardIds.add(childShardId2);
+
         // Setup leases
         // Parent lease at SHARD_END and old enough to be deleted
         Lease parentLease = createCompletedLease(
                 MULTI_STREAM_NAME,
                 parentShardId,
-                null  // no parent
+                null,  // no parent
+                childShardIds
         );
 
         // Child leases - both at SHARD_END
         Lease childLease1 = createCompletedLease(
                 MULTI_STREAM_NAME,
                 childShardId1,
-                parentShardId
+                parentShardId,
+                null
         );
 
         Lease childLease2 = createCompletedLease(
                 MULTI_STREAM_NAME,
                 childShardId2,
-                parentShardId
+                parentShardId,
+                null
         );
         StreamInfoManager streamInfoManagerMock = mock(StreamInfoManager.class);
         DynamoDBStreamsShardSyncer shardSyncer = new DynamoDBStreamsShardSyncer(true, MULTI_STREAM_NAME, false, streamInfoManagerMock);
@@ -1537,9 +1605,79 @@ public class DynamoDBStreamsShardSyncerTest {
         assertTrue(result);
 
         // Verify no leases are deleted even though all conditions for deletion are met:
-        // 1. Parent is old enough (7 hours > 6 hours)
-        // 2. All child shards are at SHARD_END
-        // 3. But cleanupLeasesOfCompletedShards is false
+        // 1. All child shards are at SHARD_END
+        // 2. But cleanupLeasesOfCompletedShards is false
         verify(leaseRefresher, never()).deleteLease(any());
+    }
+
+    @Test
+    void testChildLeaseNotDeletedBeforeParentLease() throws Exception {
+        // Setup: parent and child both at SHARD_END with childShardIds set,
+        // but parent should be deleted before child due to ordering check.
+        long baseTimestamp = System.currentTimeMillis() - Duration.ofHours(7).toMillis();
+        String parentShardId = String.format("shardId-%019d-001", baseTimestamp);
+        String childShardId = String.format("shardId-%019d-002", baseTimestamp + 1000);
+        String grandchildShardId = String.format("shardId-%019d-003", baseTimestamp + 2000);
+
+        Shard parentShard = createTestShard(parentShardId, null, null, "0", "100");
+        Shard childShard = createTestShard(childShardId, parentShardId, null, "101", "200");
+        Shard grandchildShard = createTestShard(grandchildShardId, childShardId, null, "201", null);
+
+        List<Shard> currentShards = Arrays.asList(parentShard, childShard, grandchildShard);
+
+        // Parent lease - completed, has child shard ids
+        MultiStreamLease parentLease = createCompletedLease(
+                MULTI_STREAM_NAME,
+                parentShardId,
+                null,
+                Collections.singleton(childShardId)
+        );
+
+        // Child lease - completed, has child shard ids
+        MultiStreamLease childLease = createCompletedLease(
+                MULTI_STREAM_NAME,
+                childShardId,
+                parentShardId,
+                Collections.singleton(grandchildShardId)
+        );
+
+        // Grandchild lease - active, past TRIM_HORIZON
+        MultiStreamLease grandchildLease = createActiveLease(
+                MULTI_STREAM_NAME,
+                grandchildShardId,
+                "201",
+                childShardId
+        );
+
+        List<Lease> streamLeases = Arrays.asList(parentLease, childLease, grandchildLease);
+
+        when(shardDetector.streamIdentifier()).thenReturn(MULTI_STREAM_IDENTIFIER);
+        when(shardDetector.listShards(anyString())).thenReturn(currentShards);
+        when(leaseRefresher.listLeasesForStream(MULTI_STREAM_IDENTIFIER)).thenReturn(streamLeases);
+        StreamInfoManager streamInfoManagerMock = mock(StreamInfoManager.class);
+
+        DynamoDBStreamsShardSyncer multiStreamSyncer = new DynamoDBStreamsShardSyncer(
+                true, MULTI_STREAM_NAME, true, streamInfoManagerMock);
+
+        boolean result = multiStreamSyncer.checkAndCreateLeaseForNewShards(
+                shardDetector, leaseRefresher,
+                InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.TRIM_HORIZON),
+                metricsScope, false, true);
+
+        assertTrue(result);
+
+        // Parent should be deleted (no parent of its own to wait for)
+        verify(leaseRefresher, times(1)).deleteLease(parentLease);
+        // Child should be deleted (parent was deleted first in same cycle, added to deletedLeases)
+        verify(leaseRefresher, times(1)).deleteLease(childLease);
+        // Grandchild should NOT be deleted (still active)
+        verify(leaseRefresher, never()).deleteLease(grandchildLease);
+
+        // Verify ordering: exactly 2 deletes, parent before child
+        ArgumentCaptor<Lease> deleteCaptor = ArgumentCaptor.forClass(Lease.class);
+        verify(leaseRefresher, times(2)).deleteLease(deleteCaptor.capture());
+        List<Lease> deletedInOrder = deleteCaptor.getAllValues();
+        assertEquals(parentLease.leaseKey(), deletedInOrder.get(0).leaseKey());
+        assertEquals(childLease.leaseKey(), deletedInOrder.get(1).leaseKey());
     }
 }

--- a/src/test/java/com/amazonaws/services/dynamodbv2/streamsadapter/util/StreamsLeaseCleanupValidatorTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/streamsadapter/util/StreamsLeaseCleanupValidatorTest.java
@@ -94,7 +94,7 @@ class StreamsLeaseCleanupValidatorTest {
         lease.parentShardIds(new HashSet<>(Arrays.asList("shard-1", "shard-2")));
         Set<String> currentShardIds = new HashSet<>(Arrays.asList("shard-1", "shard-4"));
 
-        Assertions.assertThrows(KinesisClientLibIOException.class, () ->
+        Assertions.assertFalse(() ->
                 StreamsLeaseCleanupValidator.isCandidateForCleanup(lease, currentShardIds, false));
     }
 
@@ -106,7 +106,7 @@ class StreamsLeaseCleanupValidatorTest {
         lease.parentShardIds(new HashSet<>(Arrays.asList("shard-1", "shard-2")));
         Set<String> currentShardIds = new HashSet<>(Arrays.asList("shard-1", "shard-4"));
 
-        Assertions.assertThrows(KinesisClientLibIOException.class, () ->
+        Assertions.assertFalse(() ->
                 StreamsLeaseCleanupValidator.isCandidateForCleanup(lease, currentShardIds, true));
     }
 

--- a/src/test/java/com/amazonaws/services/dynamodbv2/streamsadapter/util/TestUtils.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/streamsadapter/util/TestUtils.java
@@ -25,6 +25,7 @@ import software.amazon.kinesis.leases.MultiStreamLease;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 public class TestUtils {
 
@@ -221,12 +222,14 @@ public class TestUtils {
     public static MultiStreamLease createCompletedLease(
             String streamArn,
             String shardId,
-            String parentShardId) {
+            String parentShardId,
+            Set<String> childShardIds) {
         return createTestLease(
                 streamArn,
                 shardId,
                 ExtendedSequenceNumber.SHARD_END,
-                parentShardId
+                parentShardId,
+                childShardIds
         );
     }
 
@@ -248,7 +251,8 @@ public class TestUtils {
                 streamArn,
                 shardId,
                 new ExtendedSequenceNumber(sequenceNumber),
-                parentShardId
+                parentShardId,
+                null
         );
     }
 
@@ -265,7 +269,8 @@ public class TestUtils {
             String streamArn,
             String shardId,
             ExtendedSequenceNumber checkpoint,
-            String parentShardId) {
+            String parentShardId,
+            Set<String> childShardIds) {
         MultiStreamLease lease = new MultiStreamLease();
         lease.leaseKey(MultiStreamLease.getLeaseKey(streamArn, shardId));
         lease.streamIdentifier(streamArn);
@@ -274,6 +279,8 @@ public class TestUtils {
         lease.parentShardIds(parentShardId != null ?
                 Collections.singletonList(parentShardId) :
                 Collections.emptyList());
+        lease.childShardIds(childShardIds != null ?
+                childShardIds : Collections.emptyList());
         return lease;
     }
 


### PR DESCRIPTION
*Description of changes:*
Updated Logic of Clean Up - 
- Removing the 6hrs retention period check logic before a shard lease cleanup.
- Optimizing the shard cleanup process by
  - insuring child-shard-ids are set in lease to be cleaned up.
  - checking for child-shard leases in progress or finished before parent cleanup.
  - Validating parent lease clean up prior to current lease clean up.
  - child-shard-ids are updated in a lease when it reaches SHARD_END during processing, not just the current shard but it's ancestors are also updated with child-shard-ids if needed.
thus, reducing the size of lease table and eliminating data re-processing issue. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.