### PR TITLE
Set DynamoDB_Streams stream type when creating StreamIdentifier

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </licenses>
 
     <properties>
-        <software-kinesis.version>3.4.1</software-kinesis.version>
+        <software-kinesis.version>3.4.3</software-kinesis.version>
         <gpg.skip>true</gpg.skip>
         <maven.dependency.version>3.0.0</maven.dependency.version>
         <awssdk.version>2.39.6</awssdk.version>

--- a/src/main/java/com/amazonaws/services/dynamodbv2/streamsadapter/StreamsSchedulerFactory.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/streamsadapter/StreamsSchedulerFactory.java
@@ -54,6 +54,8 @@ import java.util.stream.Collectors;
 @SuppressWarnings("ParameterNumber")
 public final class StreamsSchedulerFactory {
 
+    static final String STREAM_TYPE_DYNAMODB_STREAMS = "DynamoDB_Streams";
+
     private StreamsSchedulerFactory() {}
     /**
      * Factory function for customers to create a stream tracker to consume multiple DynamoDB Streams from a single
@@ -92,7 +94,7 @@ public final class StreamsSchedulerFactory {
         List<StreamConfig> streamConfigList = dynamoDBStreamArns.stream()
                 .map(streamArn -> new StreamConfig(
                         StreamIdentifier.multiStreamInstance(createKinesisStreamIdentifierFromDynamoDBStreamsArn(
-                                streamArn, true)),
+                                streamArn, true), STREAM_TYPE_DYNAMODB_STREAMS),
                         initialPositionInStreamExtended,
                         null
                 ))
@@ -120,8 +122,11 @@ public final class StreamsSchedulerFactory {
             throw new IllegalArgumentException("Invalid Initial PositionInStream: "
                     + initialPositionInStreamExtended.getInitialPositionInStream());
         }
-        return new SingleStreamTracker(createKinesisStreamIdentifierFromDynamoDBStreamsArn(dynamoDBStreamArn,
-                false), initialPositionInStreamExtended);
+        return new SingleStreamTracker(
+                StreamIdentifier.singleStreamInstance(
+                        createKinesisStreamIdentifierFromDynamoDBStreamsArn(dynamoDBStreamArn, false),
+                        STREAM_TYPE_DYNAMODB_STREAMS),
+                initialPositionInStreamExtended);
     }
 
     /**

--- a/src/test/java/com/amazonaws/services/dynamodbv2/streamsadapter/StreamsSchedulerFactoryTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/streamsadapter/StreamsSchedulerFactoryTest.java
@@ -123,6 +123,8 @@ class StreamsSchedulerFactoryTest {
 
         assertEquals(2, configs.size());
         assertEquals(deletionStrategy, multiStreamTracker.formerStreamsLeasesDeletionStrategy());
+        configs.forEach(config -> assertEquals(StreamsSchedulerFactory.STREAM_TYPE_DYNAMODB_STREAMS,
+                config.streamIdentifier().streamType()));
     }
 
     @Test
@@ -198,6 +200,8 @@ class StreamsSchedulerFactoryTest {
 
         assertNotNull(tracker);
         assertTrue(tracker.isMultiStream() == false);
+        assertEquals(StreamsSchedulerFactory.STREAM_TYPE_DYNAMODB_STREAMS,
+                tracker.streamConfigList().get(0).streamIdentifier().streamType());
     }
 
     @Test


### PR DESCRIPTION
**Issue:** #74

**Description of changes:**

Users of the DynamoDB Streams Kinesis Adapter with KCL 3.x encounter spurious `Incomplete hash range found` ERROR logs during periodic shard sync. These logs create operational noise and trigger false alarms even though record processing works correctly.

This change sets `DynamoDB_Streams` as the stream type when creating `StreamIdentifier` objects in `StreamsSchedulerFactory`. KCL's `PeriodicShardSyncManager` uses this stream type to suppress the ERROR log for non-Kinesis streams, while hash range validation and shard sync behavior remain unchanged.

Depends on: awslabs/amazon-kinesis-client#1709