### PR TITLE
Delegate the creation of retrieval factory object to the PollingConfig class

### DIFF
--- a/src/main/java/com/amazonaws/services/dynamodbv2/streamsadapter/polling/DynamoDBStreamsPollingConfig.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/streamsadapter/polling/DynamoDBStreamsPollingConfig.java
@@ -51,14 +51,6 @@ public class DynamoDBStreamsPollingConfig extends PollingConfig {
     @Override
     public RetrievalFactory retrievalFactory() {
         recordsFetcherFactory().idleMillisBetweenCalls(idleTimeBetweenReadsInMillis);
-        return new SynchronousBlockingRetrievalFactory(
-                streamName(),
-                kinesisClient(),
-                recordsFetcherFactory(),
-                maxRecords(),
-                kinesisRequestTimeout(),
-                dataFetcherProvider(),
-                sleepTimeController()
-        );
+        return super.retrievalFactory();
     }
 }


### PR DESCRIPTION
### Description

`DynamoDBStreamsPollingConfig.retrievalFactory()` previously duplicated the full `SynchronousBlockingRetrievalFactory` construction from KCL's PollingConfig, only adding the `idleTimeBetweenReadsInMillis` configuration. This override silently dropped any new config options added to KCL's `PollingConfig.retrievalFactory()` 
- such as `maxPendingProcessRecordsInput` (added in KCL 3.3.0) - because the adapter's copy did not propagated them to the `RecordsFetcherFactory`.

This change replaces the duplicated construction with a `super.retrievalFactory()` call, so the adapter only overrides the minimal behavior it needs (setting idleTimeBetweenReadsInMillis) and delegates the rest to KCL.