### PR TITLE
Release 2.2.0 of the DynamoDB Streams Kinesis Adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-### Latest Release (v2.1.2)
+### Latest Release (v2.2.0)
+* Improves lease cleanup efficiency by removing the 6-hour retention period check.
+* Delegates retrieval factory creation to the PollingConfig base class, reducing code duplication.
+
+### Release (v2.1.2)
 * Upgrades Amazon Kinesis Client Library (KCL) to version 3.4.1.
 
 ### Release (v2.1.1)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Add the following to your Maven pom file:
 <dependency>
    <groupId>com.amazonaws</groupId>
    <artifactId>dynamodb-streams-kinesis-adapter</artifactId>
-   <version>2.1.2</version>
+   <version>2.2.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>dynamodb-streams-kinesis-adapter</artifactId>
     <packaging>jar</packaging>
     <name>DynamoDB Streams Adapter for Java</name>
-    <version>2.1.2</version>
+    <version>2.2.0</version>
     <description>The DynamoDB Streams Adapter implements the AmazonKinesis interface so that your application can use KCL to consume and process data from a DynamoDB stream.</description>
     <url>https://aws.amazon.com/dynamodb</url>
 


### PR DESCRIPTION
### Release 2.2.0 of the DynamoDB Streams Kinesis Adapter

* Improves lease cleanup efficiency by removing the 6-hour retention period check.
* Delegates retrieval factory creation to the PollingConfig base class, reducing code duplication.