### PR TITLE
Release 2.3.0 of the DynamoDB Streams Kinesis Adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-### Latest Release (v2.2.0)
+### Latest Release (v2.3.0)
+* Upgrades Amazon Kinesis Client Library (KCL) to version 3.4.3.
+* Set StreamType to suppress hash range validation ERROR logs for DynamoDB Streams.
+
+### Release (v2.2.0)
 * Improves lease cleanup efficiency by removing the 6-hour retention period check.
 * Delegates retrieval factory creation to the PollingConfig base class, reducing code duplication.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Add the following to your Maven pom file:
 <dependency>
    <groupId>com.amazonaws</groupId>
    <artifactId>dynamodb-streams-kinesis-adapter</artifactId>
-   <version>2.2.0</version>
+   <version>2.3.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>dynamodb-streams-kinesis-adapter</artifactId>
     <packaging>jar</packaging>
     <name>DynamoDB Streams Adapter for Java</name>
-    <version>2.2.0</version>
+    <version>2.3.0</version>
     <description>The DynamoDB Streams Adapter implements the AmazonKinesis interface so that your application can use KCL to consume and process data from a DynamoDB stream.</description>
     <url>https://aws.amazon.com/dynamodb</url>
 


### PR DESCRIPTION
### Description of changes

Release 2.3.0 of the DynamoDB Streams Kinesis Adapter.

### Testing

Tested DynamoDB Streams Adapter with new KCL v3.4.3 using a KCL application. 

*How the change is tested ?*

* Passed `leaseManagementConfig.leaseAssignmentStrategy(LeaseAssignmentStrategy.LEASE_COUNT_BASED);` in Scheduler.
* Got log `(Consumer-6) software.amazon.kinesis.coordinator.assignment.LeaseAssignmentManager: Started LeaseAssignmentManager using LEASE_COUNT_BASED`.
* The new LEASE_COUNT_BASED ran as expected.
* Confirmed that the default strategy is used when we do not set the lease algo in Scheduler. Confirmed it via log `(Consumer-4) software.amazon.kinesis.coordinator.assignment.LeaseAssignmentManager: Started LeaseAssignmentManager using WORKER_UTILIZATION_AWARE`


